### PR TITLE
fix: loosen capistrano version requirement

### DIFF
--- a/capistrano-systemd-ng.gemspec
+++ b/capistrano-systemd-ng.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "capistrano", ">= 3.7.0", "< 3.18.0"
+  spec.add_dependency "capistrano", ">= 3.7.0", "< 4.0.0"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/capistrano-systemd-ng.gemspec
+++ b/capistrano-systemd-ng.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "capistrano", ">= 3.7.0", "< 4.0.0"
+  spec.add_dependency "capistrano", "~> 3.7"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
Allows newer versions:
https://github.com/capistrano/capistrano/releases